### PR TITLE
CXBOX-406. Creation of new record directly in Popup (picklist, inlinePicklist and so on)

### DIFF
--- a/cxbox-core/src/main/java/org/cxbox/core/crudma/ext/impl/AnySourceBcStateCrudmaGatewayInvokeExtensionProvider.java
+++ b/cxbox-core/src/main/java/org/cxbox/core/crudma/ext/impl/AnySourceBcStateCrudmaGatewayInvokeExtensionProvider.java
@@ -23,15 +23,16 @@ import static org.cxbox.core.dto.DrillDownType.INNER;
 import static org.cxbox.core.dto.rowmeta.PostAction.BasePostActionType.DRILL_DOWN;
 
 import java.util.Arrays;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.cxbox.api.data.dto.DataResponseDTO;
 import org.cxbox.api.data.dto.DataResponseDTO_;
 import org.cxbox.api.data.dto.rowmeta.ActionDTO;
 import org.cxbox.api.data.dto.rowmeta.FieldDTO;
+import org.cxbox.api.service.tx.TransactionService;
 import org.cxbox.api.util.Invoker;
 import org.cxbox.core.controller.BCFactory;
 import org.cxbox.core.controller.param.QueryParameters;
@@ -51,6 +52,7 @@ import org.cxbox.core.dto.rowmeta.ActionsDTO;
 import org.cxbox.core.dto.rowmeta.MetaDTO;
 import org.cxbox.core.dto.rowmeta.PostAction;
 import org.cxbox.core.dto.rowmeta.PostAction.BasePostActionField;
+import org.cxbox.core.external.core.ParentDtoFirstLevelCache;
 import org.cxbox.core.service.AnySourceResponseFactory;
 import org.cxbox.core.service.AnySourceResponseService;
 import org.cxbox.core.service.action.ActionAvailableChecker;
@@ -67,9 +69,13 @@ public class AnySourceBcStateCrudmaGatewayInvokeExtensionProvider implements Cru
 
 	private final BCFactory bcFactory;
 
+	private final TransactionService transactionService;
+
 	private final AnySourceResponseFactory respFactory;
 
 	private final BcStateAware bcStateAware;
+
+	private final ParentDtoFirstLevelCache parentDtoFirstLevelCache;
 
 	@Override
 	public <T> Invoker<T, RuntimeException> extendInvoker(CrudmaAction crudmaAction, Invoker<T, RuntimeException> invoker,
@@ -83,14 +89,14 @@ public class AnySourceBcStateCrudmaGatewayInvokeExtensionProvider implements Cru
 				if (Objects.equals(crudmaAction.getActionType(), CrudmaActionType.INVOKE) &&
 						Objects.equals(ActionType.CANCEL_CREATE.getType(), crudmaAction.getName())
 				) {
-					bcStateAware.clear();
+					bcStateAware.clear(bc);
 					BcDescription description = bc.getDescription();
 					if (description instanceof AnySourceBcDescription) {
 						return (T) getResponseService(bc).onCancel(bc);
 					}
 					return (T) new ActionResultDTO().setAction(PostAction.postDelete());
 				}
-				restoreBcState(bc, action);
+				restoreBcState(bc, action, readOnly);
 				T invokeResult = invoker.invoke();
 				afterInvoke(crudmaAction, readOnly, bc, action, invokeResult);
 				return invokeResult;
@@ -102,7 +108,7 @@ public class AnySourceBcStateCrudmaGatewayInvokeExtensionProvider implements Cru
 			Object invokeResult) {
 
 		if (action != null && !readOnly) {
-			bcStateAware.clear();
+			bcStateAware.clear(bc);
 		}
 		if (Objects.equals(crudmaAction.getActionType(), CrudmaActionType.CREATE) && readOnly) {
 			InterimResult result = castToInterimResultOrElseThrow(invokeResult, crudmaAction.getActionType());
@@ -119,7 +125,7 @@ public class AnySourceBcStateCrudmaGatewayInvokeExtensionProvider implements Cru
 		if (Objects.equals(crudmaAction.getActionType(), CrudmaActionType.PREVIEW) && readOnly) {
 			InterimResult result = castToInterimResultOrElseThrow(invokeResult, crudmaAction.getActionType());
 			boolean isRecordPersisted = bcStateAware.isPersisted(bc);
-			bcStateAware.clear();
+			bcStateAware.clear(bc);
 			bcStateAware.set(
 					result.getBc(),
 					new BcState(
@@ -202,7 +208,7 @@ public class AnySourceBcStateCrudmaGatewayInvokeExtensionProvider implements Cru
 		return bc;
 	}
 
-	private void restoreBcState(final BusinessComponent currentBc, final CrudmaActionType action) {
+	private void restoreBcState(final BusinessComponent currentBc, final CrudmaActionType action, boolean readOnly) {
 		for (final BusinessComponent bc : Arrays.asList(getParentBcForRestore(currentBc), currentBc)) {
 			if (bc == null) {
 				continue;
@@ -220,12 +226,40 @@ public class AnySourceBcStateCrudmaGatewayInvokeExtensionProvider implements Cru
 				bc.setParameters(originalParameters);
 			}
 			final AnySourceResponseService<?, ?> responseService = getResponseService(bc);
-			if (!bcStateAware.isPersisted(bc)) {
-				responseService.createEntity(bc);
-			}
-			// эти действия сами вызывают update
-			if (state.getDto() != null && !Set.of(UPDATE, PREVIEW, INVOKE).contains(action)) {
-				responseService.updateEntity(bc, state.getDto());
+			if (currentBc.equals(bc)) { //current bc
+				if (!bcStateAware.isPersisted(bc)) {
+					responseService.createEntity(bc);
+				}
+
+				if (state.getDto() != null && !EnumSet.of(UPDATE, PREVIEW, INVOKE).contains(action)) {
+					responseService.updateEntity(bc, state.getDto());
+				}
+			} else { //parent
+				DataResponseDTO parentDto = null;
+				if (readOnly) { //restore parent for read only childes operations. For example, we create new task and read reviewers from picklist (that is child for task.
+
+					if (!bcStateAware.isPersisted(bc)) {
+						parentDto = responseService.createEntity(bc).getRecord();
+					}
+
+					if (state.getDto() != null) { //we always restore parent
+						parentDto = responseService.updateEntity(bc, state.getDto()).getRecord();
+					}
+				} else { //restore parent for non read only childes. For example, we create new task and read reviewers from picklist AND then CREATE new reviewer in popup.
+					// So in this case we roll back parent right here and recommend users to use VersionAware.getParentDTO() instead of finding parent in DB by id
+					parentDto = transactionService.invokeInNewRollbackOnlyTx(() -> {
+						DataResponseDTO result = null;
+						if (!bcStateAware.isPersisted(bc)) {
+							result = responseService.createEntity(bc).getRecord();
+						}
+
+						if (state.getDto() != null) { //we always restore parent
+							result = responseService.updateEntity(bc, state.getDto()).getRecord();
+						}
+						return result;
+					});
+				}
+				parentDtoFirstLevelCache.getCache().put(bc.getName(), Optional.ofNullable(parentDto));
 			}
 		}
 	}

--- a/cxbox-core/src/main/java/org/cxbox/core/crudma/state/BcStateAware.java
+++ b/cxbox-core/src/main/java/org/cxbox/core/crudma/state/BcStateAware.java
@@ -38,7 +38,7 @@ public interface BcStateAware {
 	/**
 	 * Clear all state records for current client
 	 */
-	void clear();
+	void clear(BusinessComponent bc);
 
 	/**
 	 * Change state for business component instance

--- a/cxbox-core/src/main/java/org/cxbox/core/crudma/state/impl/BcStateAwareImpl.java
+++ b/cxbox-core/src/main/java/org/cxbox/core/crudma/state/impl/BcStateAwareImpl.java
@@ -49,9 +49,9 @@ public class BcStateAwareImpl implements BcStateAware {
 	private static final String NO_CLIENT = "NO_CLIENT";
 
 	@Override
-	public void clear() {
+	public void clear(BusinessComponent bc) {
 		ClientStorage storage = getStorage();
-		Optional.ofNullable(getState(storage)).ifPresent(Map::clear);
+		Optional.ofNullable(getState(storage)).ifPresent(state -> state.remove(BcKey.of(bc)));
 		flushStorage(storage);
 	}
 

--- a/cxbox-core/src/main/java/org/cxbox/core/external/core/ParentDtoFirstLevelCache.java
+++ b/cxbox-core/src/main/java/org/cxbox/core/external/core/ParentDtoFirstLevelCache.java
@@ -1,0 +1,22 @@
+package org.cxbox.core.external.core;
+
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import lombok.Getter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.annotation.RequestScope;
+
+
+/**
+ * Stores PARENT DTO of current request bc.
+ * Mote! DOES NOT store dto of current bc
+ */
+
+@Getter
+@Component
+@RequestScope
+public class ParentDtoFirstLevelCache<E> {
+
+	private final ConcurrentHashMap<String, Optional<E>> cache = new ConcurrentHashMap<>();
+
+}

--- a/cxbox-core/src/test/java/org/cxbox/core/crudma/state/impl/BcStateAwareImplTest.java
+++ b/cxbox-core/src/test/java/org/cxbox/core/crudma/state/impl/BcStateAwareImplTest.java
@@ -70,7 +70,7 @@ class BcStateAwareImplTest {
 				BUSINESS_COMPONENT,
 				STATE
 		);
-		bcStateAware.clear();
+		bcStateAware.clear(BUSINESS_COMPONENT);
 		Assertions.assertNull(bcStateAware.getState(BUSINESS_COMPONENT));
 	}
 


### PR DESCRIPTION
1) BcStateAware now cleans cache only for exact bc (for user session), when terminal action request completed (instead of whole cache for user session)
2) AbstractAnySourceResponseService and AbstractResponseService now have new method protected <P extends DataResponseDTO, F> F getParentField(DtoField<P, F> dtoField, BusinessComponent bc) to simply get Parent bc DTO field values.
Usage example: getParentField(<PARENT_DTO>_.<parent_field>, bc);
3) Added support of creation new records directly in popups (picklist and so on). AbstractAnySourceResponseService and AbstractResponseService can be used for this popups services with the only restriction -- one must use new method (see 2) ) instead of repository.findById(bc.getParentIdAsLong()) to get parent values if needed.
> If popup is not used for creation new records directly in it - this restriction can be ignored (e.g. there is no need to change old popup services code)
> See details in see org.cxbox.core.crudma.impl.AbstractResponseService#getParentField(org.cxbox.constgen.DtoField, org.cxbox.core.crudma.bc.BusinessComponent) java doc