### PR TITLE
CXBOX-436. LOV sorting in filter and edit dropdowns by display_order

### DIFF
--- a/cxbox-core/src/main/java/org/cxbox/core/dto/rowmeta/RowDependentFieldsMeta.java
+++ b/cxbox-core/src/main/java/org/cxbox/core/dto/rowmeta/RowDependentFieldsMeta.java
@@ -19,7 +19,9 @@ package org.cxbox.core.dto.rowmeta;
 import static org.cxbox.api.data.dictionary.DictionaryCache.dictionary;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Comparator;
 import org.cxbox.api.config.CxboxBeanProperties;
+import org.cxbox.api.data.dictionary.DictionaryCache;
 import org.cxbox.api.data.dictionary.IDictionaryType;
 import org.cxbox.api.data.dictionary.LOV;
 import org.cxbox.api.data.dictionary.SimpleDictionary;
@@ -143,6 +145,18 @@ public class RowDependentFieldsMeta<T extends DataResponseDTO> extends FieldsDTO
 				.ifPresent(fieldDTO -> fieldDTO.setDisabled(disabled)));
 	}
 
+	/**
+	 * @param field dto field
+	 * @param type dictionary type
+	 * <p>
+	 * <br>
+	 * field edit drop-downs (Form widget field during editing and so on) values sorted by display_order, then by key. display_order can be null
+	 * <p>
+	 * See dicts.sort and LinkedHashMap lines in {@link org.cxbox.model.core.service.DictionaryCacheImpl.Cache#load()}
+	 * <p>
+	 * <br>
+	 * Attention - sorting rows in List widgets always ignores display_order and is done by lov.key lexicographically!
+	 */
 	public final void setDictionaryTypeWithAllValues(DtoField<? super T, ?> field, IDictionaryType type) {
 		setDictionaryTypeWithAllValues(field, type.getName());
 	}
@@ -154,6 +168,24 @@ public class RowDependentFieldsMeta<T extends DataResponseDTO> extends FieldsDTO
 					fieldDTO.clearValues();
 					fieldDTO.setValues(dictionary().getAll(type));
 				});
+	}
+
+	/**
+	 * @param field dto field
+	 * @param type dictionary type
+	 * @param comparator field edit drop-downs (Form widget field during editing and so on) show values sorted by this comparator
+	 * <p>
+	 * Attention - sorting rows in List widgets always ignores display_order and is done by lov.key lexicographically!
+	 */
+	private void setDictionaryTypeWithAllValues(
+			final DtoField<?, ?> field,
+			@NonNull final String type,
+			@NonNull final Comparator<SimpleDictionary> comparator) {
+		Optional.ofNullable(field).map(dtoField -> fields.get(dtoField.getName())).ifPresent(fieldDTO -> {
+			fieldDTO.setDictionaryName(type);
+			fieldDTO.clearValues();
+			fieldDTO.setValues(DictionaryCache.dictionary().getAll(type).stream().sorted(comparator).toList());
+		});
 	}
 
 	@Deprecated

--- a/cxbox-model/cxbox-model-core/src/main/java/org/cxbox/model/core/service/DictionaryCacheImpl.java
+++ b/cxbox-model/cxbox-model-core/src/main/java/org/cxbox/model/core/service/DictionaryCacheImpl.java
@@ -308,7 +308,8 @@ public class DictionaryCacheImpl implements DictionaryCache {
 			syncLanguages(data);
 			data.forEach((lang, typeaware) -> typeaware.forEach((type, dictmap) -> {
 				List<SimpleDictionary> dicts = new ArrayList<>(dictmap.values());
-				dicts.sort(Comparator.comparing(SimpleDictionary::getDisplayOrder));
+				//sort by displayOrder, then by key. displayOrder can be null
+				dicts.sort(Comparator.comparing(SimpleDictionary::getDisplayOrder, Comparator.nullsLast(Integer::compare)).thenComparing(SimpleDictionary::getKey));
 				dicts.forEach(dict -> {
 					byKey.get(lang).computeIfAbsent(type, v -> new LinkedHashMap<>()).put(dict.getKey(), dict);
 					byValue.get(lang).computeIfAbsent(type, v -> new LinkedHashMap<>()).put(dict.getValue(), dict);


### PR DESCRIPTION
1. **removed**: FieldsMeta class method 
```
setAllFilterValuesByLovTypeOrdered(final FieldsMeta<?> fields,
     final DtoField<?, ?> field,
     final IDictionaryType type)
```
 it duplicates setAllFilterValuesByLovType and has NPE problem, when display_order is null
3. **removed**: FieldsMeta class method 
```
setAllFilterValuesByLovType(final FieldsMeta<?> fields,
    final DtoField<?, ?> field,
    final IDictionaryType type,
    final Comparator<SimpleDictionary> comparator)
```
it has wrong private modifier, wrong input argument fields (it is class field)
5. **removed**: FieldsMeta class method setDictionaryTypeWithAllValuesOrdered - it was declared in wrong class (correct cass is RowDependentFieldsMeta). Also it duplicates setDictionaryTypeWithAllValues and has NPE problem, when display_order is null
6. **removed**: FieldsMeta class method setDictionaryTypeWithAllValues - it was declared in wrong class (correct cass is RowDependentFieldsMeta). Also, it has wrong private modifier, wrong input argument fields (it is class field)
---correct realization---
7. **fixed**: LOV dictionary loader : 
NOW: sorting items by display_order, then by key (display_order can be null)
WAS: sorting items by display_order (display_order could not be null)
8. **added java doc for old method:** `setAllFilterValuesByLovType(DtoField<? super T, ?> field, IDictionaryType type)` describing, that this method already sorts by display_order
```
/**
	 * @param field dto field
	 * @param type dictionary type
	 * <p>
	 * <br>
	 * Field filter drop-downs (on List widgets header and so on) values sorted by display_order, then by key. display_order can be null
	 * <p>
	 * See dicts.sort and LinkedHashMap lines in {@link org.cxbox.model.core.service.DictionaryCacheImpl.Cache#load()}
	 * <p>
	 * <br>
	 * Attention - sorting rows in List widgets always ignores display_order and is done by lov.key lexicographically!
	 */
```
9. **added new method**: at FieldsMeta class
```
public final void setAllFilterValuesByLovType(
   			final DtoField<?, ?> field,
   			@NonNull final IDictionaryType type,
   			@NonNull final Comparator<SimpleDictionary> comparator)
```
with java doc
```
/**
	 * @param field dto field
	 * @param type dictionary type
	 * @param comparator filter drop-downs will show values sorted by this comparator
	 * <p>
	 * Attention - sorting rows in List widgets always ignores display_order and is done by lov.key lexicographically!
	 */
```
10. **added java doc for old method**: setDictionaryTypeWithAllValues(DtoField<? super T, ?> field, IDictionaryType type) describing, that it already sorts by display_order

```
/**
	 * @param field dto field
	 * @param type dictionary type
	 * <p>
	 * <br>
	 * field edit drop-downs (Form widget field during editing and so on) values sorted by display_order, then by key. display_order can be null
	 * <p>
	 * See dicts.sort and LinkedHashMap lines in {@link org.cxbox.model.core.service.DictionaryCacheImpl.Cache#load()}
	 * <p>
	 * <br>
	 * Attention - sorting rows in List widgets always ignores display_order and is done by lov.key lexicographically!
	 */
```
11. **added new method**: at RowDependentFieldsMeta class 
```
setDictionaryTypeWithAllValues(
      final DtoField<?, ?> field,
      @NonNull final String type,
      @NonNull final Comparator<SimpleDictionary> comparator)
```
with java doc 
```
/**
	 * @param field dto field
	 * @param type dictionary type
	 * @param comparator field edit drop-downs (Form widget field during editing and so on) show values sorted by this comparator
	 * <p>
	 * Attention - sorting rows in List widgets always ignores display_order and is done by lov.key lexicographically!
	 */
```