### PR TITLE
CXBOX-460 | flush and setWithFirstLevelCache return the entity.

### DIFF
--- a/cxbox-core/src/main/java/org/cxbox/core/dao/AnySourceBaseDAO.java
+++ b/cxbox-core/src/main/java/org/cxbox/core/dao/AnySourceBaseDAO.java
@@ -55,7 +55,7 @@ public interface AnySourceBaseDAO<E> {
 	/**
 	 * Put to First Level Cache
 	 */
-	void setWithFirstLevelCache(BusinessComponent bc, E entity);
+	E setWithFirstLevelCache(BusinessComponent bc, E entity);
 
 	/**
 	 * Should not be used anywhere except of {@link AbstractAnySourceBaseDAO}
@@ -65,7 +65,7 @@ public interface AnySourceBaseDAO<E> {
 	/**
 	 * Should be used to explicitly update/create in anySource system by custom action
 	 */
-	void flush(BusinessComponent bc);
+	E flush(BusinessComponent bc);
 
 	/**
 	 * Should not be used anywhere except of {@link AbstractAnySourceBaseDAO}

--- a/cxbox-core/src/main/java/org/cxbox/core/dao/impl/AbstractAnySourceBaseDAO.java
+++ b/cxbox-core/src/main/java/org/cxbox/core/dao/impl/AbstractAnySourceBaseDAO.java
@@ -57,16 +57,16 @@ public abstract class AbstractAnySourceBaseDAO<E> implements AnySourceBaseDAO<E>
 	}
 
 	@Override
-	public void setWithFirstLevelCache(BusinessComponent bc, E entity) {
-		cache.getCache().put(bc.getName(), entity);
+	public E setWithFirstLevelCache(BusinessComponent bc, E entity) {
+		return cache.getCache().put(bc.getName(), entity);
 	}
 
 	@Override
-	public void flush(BusinessComponent bc) {
+	public E flush(BusinessComponent bc) {
 		if (anySourceBcStateAware.isPersisted(bc)) {
-			setWithFirstLevelCache(bc, update(bc, getById(bc)));
+			return setWithFirstLevelCache(bc, update(bc, getById(bc)));
 		} else {
-			setWithFirstLevelCache(bc, create(bc, getById(bc)));
+			return setWithFirstLevelCache(bc, create(bc, getById(bc)));
 		}
 	}
 


### PR DESCRIPTION
Breaking change. If you are implementing the AnySourceBaseDAO interface, you need to change the return value from void to entity