### PR TITLE
bugfix.

### DIFF
--- a/cxbox-core/src/main/java/org/cxbox/core/crudma/impl/AbstractAnySourceResponseService.java
+++ b/cxbox-core/src/main/java/org/cxbox/core/crudma/impl/AbstractAnySourceResponseService.java
@@ -109,7 +109,7 @@ public abstract class AbstractAnySourceResponseService<T extends DataResponseDTO
 	private APIProperties apiProperties;
 
 	@Autowired
-	private ParentDtoFirstLevelCache<?> parentDtoFirstLevelCache;
+	private ParentDtoFirstLevelCache parentDtoFirstLevelCache;
 
 	@Override
 	public AnySourceBaseDAO<E> getBaseDao() {
@@ -439,21 +439,18 @@ public abstract class AbstractAnySourceResponseService<T extends DataResponseDTO
 	}
 
 	/**
-	 * see org.cxbox.core.crudma.impl.AbstractResponseService#getParentField(org.cxbox.constgen.DtoField, org.cxbox.core.crudma.bc.BusinessComponent)
+	 * see {@link org.cxbox.core.crudma.impl.AbstractResponseService#getParentField(org.cxbox.constgen.DtoField, org.cxbox.core.crudma.bc.BusinessComponent)}
+	 * <br>
 	 * Note! AnySource api do not restore bc state with insert/update to DB and 'rollback'/'commit' changes if user 'did not complete'/'completed' process,
 	 * but restores state in fully independent custom cache, so all any source bc's can be fetched with baseDao.getById()
-	 * -----------
+	 * <br>
+	 * <br>
 	 * But you can use AnySource service as child and VersionAware as parent,
 	 * so when CREATING ROW directly in child popup, then parent can again be fetched only
-	 * with this method see org.cxbox.core.crudma.impl.AbstractResponseService#getParentField(org.cxbox.constgen.DtoField, org.cxbox.core.crudma.bc.BusinessComponent)
+	 * with this method see {@link org.cxbox.core.crudma.impl.AbstractResponseService#getParentField(org.cxbox.constgen.DtoField, org.cxbox.core.crudma.bc.BusinessComponent)})
 	 */
 	protected <P extends DataResponseDTO, F> F getParentField(DtoField<P, F> dtoField, BusinessComponent bc) {
-		Optional<?> parent = parentDtoFirstLevelCache.getCache().get(bc.getParentName());
-		if (parent == null) {
-			return null;
-		}
-		P parentDto = (P) parent.orElse(null);
-		return Optional.ofNullable(parentDto).map(dtoField.getGetter()).orElse(null);
+		return parentDtoFirstLevelCache.getParentField(dtoField, bc);
 	}
 
 	protected final E isExist(final BusinessComponent bc) {

--- a/cxbox-core/src/main/java/org/cxbox/core/crudma/impl/AbstractResponseService.java
+++ b/cxbox-core/src/main/java/org/cxbox/core/crudma/impl/AbstractResponseService.java
@@ -112,7 +112,7 @@ public abstract class AbstractResponseService<T extends DataResponseDTO, E exten
 	private DTOMapper dtoMapper;
 
 	@Autowired
-	private ParentDtoFirstLevelCache<?> parentDtoFirstLevelCache;
+	private ParentDtoFirstLevelCache parentDtoFirstLevelCache;
 
 
 	public static <T> T cast(Object o, Class<T> clazz) {
@@ -505,25 +505,25 @@ public abstract class AbstractResponseService<T extends DataResponseDTO, E exten
 	 * @param <F> parent DTO field type
 	 * @return parent DTO
 	 * In this DTO you'll get parent state including not persisted yet changes. Cases:
+	 * <br>
 	 * 1) parent is saved to persistence storage - it will be mapped to DTO with entityToDTO method and returned as DTO
+	 * <br>
 	 * 2) parent is saved to persistence storage and have new not yet persisted changes that backend already knows about (for example parent have force active field that was changed and this change is stored in BcStateAware).
 	 * In this case entity will be fetched from persistence storage and then changes from BcStateAware will be applied with doUpdate method, so you'll get parent DTO with ALL CHANGES backend already knows about
+	 * <br>
 	 * 3) parent is in creation process and have new not yet persisted changes - result will be same as in 2), e.g. you'll get parent DTO with ALL CHANGES backend already knows about
-	 * -----------
+	 * <br>
+	 * <br>
 	 * CREATE new row directly in popup:
 	 * One MUST use this method, when service is used to CREATE new row directly in popup, because in this case the only way to get data from parent is this method
 	 * Why behaviour is different? Why you cannot not get parent with repository findById(bc.getParentIdAsLong())? Because commiting changes to new child in popup, would have to commit not yet persisted changes in parent TOO which is wrong and breaks parent creation cancellation, so parent not persisted changes is not available in DB at all when child action is not readonly (e.g. changes will not be rolled back)!
-	 * -----------
+	 * <br>
+	 * <br>
 	 * Other, then CREATE new row directly in popup cases:
 	 * Fill free to use this method, or as usually get parent with repository findById(bc.getParentIdAsLong())
 	 */
 	protected <P extends DataResponseDTO, F> F getParentField(DtoField<P, F> dtoField, BusinessComponent bc) {
-		Optional<?> parent = parentDtoFirstLevelCache.getCache().get(bc.getParentName());
-		if (parent == null) {
-			return null;
-		}
-		P parentDto = (P) parent.orElse(null);
-		return Optional.ofNullable(parentDto).map(dtoField.getGetter()).orElse(null);
+		return parentDtoFirstLevelCache.getParentField(dtoField, bc);
 	}
 
 	protected final E isExist(final Long id) {

--- a/cxbox-core/src/main/java/org/cxbox/core/external/core/ParentDtoFirstLevelCache.java
+++ b/cxbox-core/src/main/java/org/cxbox/core/external/core/ParentDtoFirstLevelCache.java
@@ -2,21 +2,182 @@ package org.cxbox.core.external.core;
 
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
-import lombok.Getter;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.cxbox.api.data.dto.DataResponseDTO;
+import org.cxbox.api.service.tx.TransactionService;
+import org.cxbox.constgen.DtoField;
+import org.cxbox.core.controller.BCFactory;
+import org.cxbox.core.controller.param.QueryParameters;
+import org.cxbox.core.crudma.bc.BusinessComponent;
+import org.cxbox.core.crudma.bc.impl.AnySourceBcDescription;
+import org.cxbox.core.crudma.bc.impl.InnerBcDescription;
+import org.cxbox.core.crudma.state.BcState;
+import org.cxbox.core.crudma.state.BcStateAware;
+import org.cxbox.core.service.AnySourceResponseFactory;
+import org.cxbox.core.service.AnySourceResponseService;
+import org.cxbox.core.service.ResponseFactory;
+import org.cxbox.core.service.ResponseService;
+import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Component;
 import org.springframework.web.context.annotation.RequestScope;
 
 
 /**
- * Stores PARENT DTO of current request bc.
- * Mote! DOES NOT store dto of current bc
+ * Stores parent DTO of current request bc.
+ * Note! cache do NOT store dto of current bc
  */
-
-@Getter
 @Component
 @RequestScope
-public class ParentDtoFirstLevelCache<E> {
+@RequiredArgsConstructor
+public class ParentDtoFirstLevelCache {
 
-	private final ConcurrentHashMap<String, Optional<E>> cache = new ConcurrentHashMap<>();
+	private final ConcurrentHashMap<String, DataResponseDTO> cache = new ConcurrentHashMap<>();
+
+	private final ResponseFactory respFactory;
+
+	private final AnySourceResponseFactory anySourceResponseFactory;
+
+	private final BCFactory bcFactory;
+
+	private final TransactionService transactionService;
+
+	private final BcStateAware bcStateAware;
+
+	private <T extends DataResponseDTO> void putCacheValue(BusinessComponent parentBc, T value) {
+		this.cache.put(parentBc.getName(), value);
+	}
+
+	public void restoreParentBc(boolean readOnly, BusinessComponent childBc) {
+		var parentBc = this.getParentBcForRestore(childBc);
+		if (parentBc != null) {
+			if (parentBc.getDescription() instanceof AnySourceBcDescription) {
+				restoreAnySourceParentBc(readOnly, parentBc);
+			}
+			if (parentBc.getDescription() instanceof InnerBcDescription) {
+				restoreInnerBc(readOnly, parentBc);
+			}
+		}
+	}
+
+	public <P extends DataResponseDTO, F> F getParentField(DtoField<P, F> dtoField, BusinessComponent childBc) {
+		P parentDto = getOneParentBcStateAware(childBc);
+		return Optional.ofNullable(parentDto).map(dtoField.getGetter()).orElse(null);
+	}
+
+	private <P extends DataResponseDTO> P getOneParentBcStateAware(BusinessComponent childBc) {
+		var parentDto = this.cache.get(childBc.getParentName());
+		if (parentDto == null) {
+			parentDto = getOneParent(childBc).orElse(null);
+		}
+		return (P) parentDto;
+	}
+
+	private Optional<? extends DataResponseDTO> getOneParent(BusinessComponent childBc) {
+		var parentBc = getParentBcForRestore(childBc);
+		if (parentBc == null) {
+			return Optional.empty();
+		}
+		if (parentBc.getDescription() instanceof AnySourceBcDescription) {
+			return Optional.ofNullable(getAnySourceResponseService(parentBc).getOne(parentBc));
+		}
+		if (parentBc.getDescription() instanceof InnerBcDescription) {
+			return Optional.ofNullable(getInnerBcResponseService(parentBc).getOne(parentBc));
+		}
+		return Optional.empty();
+	}
+
+	private void restoreAnySourceParentBc(boolean readOnly, BusinessComponent bc) {
+		if (bc != null && (bc.getDescription() instanceof AnySourceBcDescription)) {
+			final BcState state = bcStateAware.getState(bc);
+			if (state != null) {
+				if (state.getPendingAction() != null) {
+					QueryParameters originalParameters = bc.getParameters();
+					originalParameters.setParameter("_action", state.getPendingAction());
+					bc.setParameters(originalParameters);
+				}
+				final AnySourceResponseService<?, ?> responseService = this.getAnySourceResponseService(bc);
+				DataResponseDTO parentDto = null;
+				if (readOnly) { //restore parent for read only childes operations. For example, we create new task and read reviewers from picklist (that is child for task.
+					if (!bcStateAware.isPersisted(bc)) {
+						parentDto = responseService.createEntity(bc).getRecord();
+					}
+					if (state.getDto() != null) { //we always restore parent
+						parentDto = responseService.updateEntity(bc, state.getDto()).getRecord();
+					}
+				} else { //restore parent for non read only childes. For example, we create new task and read reviewers from picklist AND then CREATE new reviewer in popup.
+					// So in this case we roll back parent right here and recommend users to use VersionAware.getParentDTO() instead of finding parent in DB by id
+					parentDto = transactionService.invokeInNewRollbackOnlyTx(() -> {
+						DataResponseDTO result = null;
+						if (!bcStateAware.isPersisted(bc)) {
+							result = responseService.createEntity(bc).getRecord();
+						}
+						if (state.getDto() != null) { //we always restore parent
+							result = responseService.updateEntity(bc, state.getDto()).getRecord();
+						}
+						return result;
+					});
+				}
+				this.putCacheValue(bc, parentDto);
+			}
+		}
+	}
+
+	private void restoreInnerBc(boolean readOnly, @Nullable BusinessComponent bc) {
+		if (bc != null && (bc.getDescription() instanceof InnerBcDescription)) {
+			final BcState state = bcStateAware.getState(bc);
+			if (state != null) {
+				if (state.getPendingAction() != null) {
+					QueryParameters originalParameters = bc.getParameters();
+					originalParameters.setParameter("_action", state.getPendingAction());
+					bc.setParameters(originalParameters);
+				}
+				final ResponseService<?, ?> responseService = this.getInnerBcResponseService(bc);
+				DataResponseDTO parentDto = null;
+				if (readOnly) { //restore parent for read only childes operations. For example, we create new task and read reviewers from picklist (that is child for task.
+					if (!bcStateAware.isPersisted(bc)) {
+						parentDto = responseService.createEntity(bc).getRecord();
+					}
+					if (state.getDto() != null) { //we always restore parent
+						parentDto = responseService.updateEntity(bc, state.getDto()).getRecord();
+					}
+				} else { //restore parent for non read only childes. For example, we create new task and read reviewers from picklist AND then CREATE new reviewer in popup.
+					// So in this case we roll back parent right here and recommend users to use VersionAware.getParentDTO() instead of finding parent in DB by id
+					parentDto = transactionService.invokeInNewRollbackOnlyTx(() -> {
+						DataResponseDTO result = null;
+						if (!bcStateAware.isPersisted(bc)) {
+							result = responseService.createEntity(bc).getRecord();
+						}
+						if (state.getDto() != null) { //we always restore parent
+							result = responseService.updateEntity(bc, state.getDto()).getRecord();
+						}
+						return result;
+					});
+				}
+				this.putCacheValue(bc, parentDto);
+			}
+		}
+	}
+
+	@Nullable
+	public BusinessComponent getParentBcForRestore(@NonNull final BusinessComponent childBc) {
+		if (childBc.getHierarchy() == null || childBc.getHierarchy().getParent() == null) {
+			return null;
+		}
+		return bcFactory.getBusinessComponent(
+				childBc.getHierarchy().getParent(),
+				QueryParameters.onlyDatesQueryParameters(
+						childBc.getParameters()
+				)
+		);
+	}
+
+	public AnySourceResponseService<?, ?> getAnySourceResponseService(BusinessComponent bc) {
+		return anySourceResponseFactory.getService(bc.getDescription());
+	}
+
+	public ResponseService<?, ?> getInnerBcResponseService(BusinessComponent bc) {
+		return respFactory.getService(bc.getDescription());
+	}
 
 }

--- a/cxbox-core/src/test/java/org/cxbox/core/crudma/ext/impl/BcStateCrudmaGatewayInvokeExtensionProviderTest.java
+++ b/cxbox-core/src/test/java/org/cxbox/core/crudma/ext/impl/BcStateCrudmaGatewayInvokeExtensionProviderTest.java
@@ -46,6 +46,7 @@ import org.cxbox.core.dto.rowmeta.ActionsDTO;
 import org.cxbox.core.dto.rowmeta.MetaDTO;
 import org.cxbox.core.dto.rowmeta.PostAction;
 import org.cxbox.core.dto.rowmeta.RowMetaDTO;
+import org.cxbox.core.external.core.ParentDtoFirstLevelCache;
 import org.cxbox.core.service.ResponseFactory;
 import org.cxbox.core.service.ResponseService;
 import org.cxbox.core.test.util.TestResponseDto;
@@ -70,6 +71,9 @@ class BcStateCrudmaGatewayInvokeExtensionProviderTest {
 
 	@Mock
 	BcStateAware bcStateAware;
+
+	@Mock
+	ParentDtoFirstLevelCache parentDtoFirstLevelCache;
 
 	private BcDescription bcDescription;
 


### PR DESCRIPTION
1) getParentField method of *VersionAware services now takes value from DB/storage, if no cached value found 
2) when AnySource and usual bcs are combined as parent/child of child/parent - now parent is correctly restored (e.g will be available in DB with last force active changes and will be available by getParentField() method with last force active changes