### PR TITLE
CXBOX-643 | Role View. Role Screen Override. File Controller byte[] replaced with IO Stream

### DIFF
--- a/cxbox-bom/pom.xml
+++ b/cxbox-bom/pom.xml
@@ -86,6 +86,26 @@
       </dependency>
       <dependency>
         <groupId>org.cxbox</groupId>
+        <artifactId>cxbox-dictionary-api-internal</artifactId>
+        <version>4.0.0-M12-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>org.cxbox</groupId>
+        <artifactId>cxbox-dictionary-api</artifactId>
+        <version>4.0.0-M12-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>org.cxbox</groupId>
+        <artifactId>cxbox-dictionary-jackson</artifactId>
+        <version>4.0.0-M12-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>org.cxbox</groupId>
+        <artifactId>cxbox-dictionary-hibernate</artifactId>
+        <version>4.0.0-M12-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>org.cxbox</groupId>
         <artifactId>cxbox-dictionary-crudma</artifactId>
         <version>4.0.0-M12-SNAPSHOT</version>
       </dependency>

--- a/cxbox-core/src/main/java/org/cxbox/core/file/controller/CxboxFileController.java
+++ b/cxbox-core/src/main/java/org/cxbox/core/file/controller/CxboxFileController.java
@@ -16,6 +16,10 @@
 
 package org.cxbox.core.file.controller;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Objects;
 import org.cxbox.core.file.dto.CxboxResponseDTO;
 import org.cxbox.core.file.dto.FileUploadDto;
 import java.nio.charset.StandardCharsets;
@@ -24,8 +28,10 @@ import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.InvalidMediaTypeException;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
 
 /**
  * Add
@@ -34,8 +40,9 @@ import org.springframework.web.multipart.MultipartFile;
  * @RequestMapping(CXBOX_API_PATH_SPEL + "/file")
  * }</pre>
  * on implementation class
- * */
-public interface CxboxFileController {
+ */
+public interface CxboxFileController<D> {
+
 
 	/**
 	 * Add
@@ -44,7 +51,7 @@ public interface CxboxFileController {
 	 * }</pre>
 	 * on implementation class.
 	 * You can extend api for /file endpoint (declaring method with another signature), so we are not placing @PostMapping on interface to avoid endpoints clash
-	 * */
+	 */
 	CxboxResponseDTO<? extends FileUploadDto> upload(
 			@RequestParam("file") MultipartFile file,
 			@RequestParam(value = "source", required = false) String source);
@@ -59,8 +66,8 @@ public interface CxboxFileController {
 	 * You can extend api for /file endpoint (declaring method with another signature), so we are not placing @PostMapping on interface to avoid endpoints clash.
 	 * <pre></pre>
 	 * See buildFileHttpEntity example of constructing response for this method
-	 * */
-	HttpEntity<byte[]> download(
+	 */
+	HttpEntity<D> download(
 			@RequestParam("id") String id,
 			@RequestParam(value = "source", required = false) String source,
 			@RequestParam(value = "preview", required = false, defaultValue = "false") boolean preview);
@@ -72,24 +79,50 @@ public interface CxboxFileController {
 	 * }</pre>
 	 * on implementation class.
 	 * You can extend api for /file endpoint (declaring method with another signature), so we are not placing @PostMapping on interface to avoid endpoints clash
-	 * */
+	 */
 	CxboxResponseDTO<Void> remove(
 			@RequestParam("id") String id,
 			@RequestParam("source") String source);
 
 
-	default HttpEntity<byte[]> buildFileHttpEntity(byte[] content, String fileName, String fileType, boolean inline) {
-		HttpHeaders header = new HttpHeaders();
-		header.set(
+	default HttpEntity<StreamingResponseBody> buildFileHttpEntity(InputStream content, Long length, String fileName,
+			String fileType, boolean preview) {
+		HttpHeaders headers = new HttpHeaders();
+		headers.set(
 				HttpHeaders.CONTENT_DISPOSITION,
-				ContentDisposition.builder(inline ? "inline" : "attachment")
+				ContentDisposition.builder(preview ? "inline" : "attachment")
 						.filename(fileName, StandardCharsets.UTF_8)
 						.build()
 						.toString()
 		);
-		header.setContentType(getMediaType(fileType));
-		header.setContentLength(content.length);
-		return new HttpEntity<>(content, header);
+		headers.setContentType(getMediaType(fileType));
+		headers.setContentLength(length);
+		return ResponseEntity.ok()
+				.headers(headers)
+				.body(outputStream -> copy(content, outputStream, getChunkSize()));
+	}
+
+	default int getChunkSize() {
+		int mib = 1048576;
+		return mib * 5;
+	}
+
+	default long copy(final InputStream inputStream, final OutputStream outputStream, final int bufferSize)
+			throws IOException {
+		return copyLarge(inputStream, outputStream, new byte[bufferSize]);
+	}
+
+	default long copyLarge(final InputStream inputStream, final OutputStream outputStream, final byte[] buffer)
+			throws IOException {
+		Objects.requireNonNull(inputStream, "inputStream");
+		Objects.requireNonNull(outputStream, "outputStream");
+		long count = 0;
+		int n;
+		while (-1 != (n = inputStream.read(buffer))) {
+			outputStream.write(buffer, 0, n);
+			count += n;
+		}
+		return count;
 	}
 
 	default MediaType getMediaType(final String type) {

--- a/cxbox-core/src/main/java/org/cxbox/core/file/controller/CxboxFileControllerSimple.java
+++ b/cxbox-core/src/main/java/org/cxbox/core/file/controller/CxboxFileControllerSimple.java
@@ -33,13 +33,14 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
 
 @Slf4j
 @RestController
 @RequiredArgsConstructor
 @RequestMapping(CXBOX_API_PATH_SPEL + "/file")
 @ConditionalOnMissingBean(CxboxFileController.class)
-public class CxboxFileControllerSimple implements CxboxFileController {
+public class CxboxFileControllerSimple implements CxboxFileController<StreamingResponseBody> {
 
 	private final CxboxFileService cxboxFileService;
 
@@ -53,9 +54,9 @@ public class CxboxFileControllerSimple implements CxboxFileController {
 
 	@Override
 	@GetMapping
-	public HttpEntity<byte[]> download(String id, String source, boolean preview) {
+	public HttpEntity<StreamingResponseBody> download(String id, String source, boolean preview) {
 		FileDownloadDto file = cxboxFileService.download(id, source);
-		return buildFileHttpEntity(file.getBytes(), file.getName(), file.getType(), preview);
+		return buildFileHttpEntity(file.getContent().get(), file.getLength(), file.getName(), file.getType(), preview);
 	}
 
 	@Override

--- a/cxbox-core/src/main/java/org/cxbox/core/file/dto/FileDownloadDto.java
+++ b/cxbox-core/src/main/java/org/cxbox/core/file/dto/FileDownloadDto.java
@@ -16,17 +16,60 @@
 
 package org.cxbox.core.file.dto;
 
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.util.function.Supplier;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
+import lombok.NonNull;
+import lombok.SneakyThrows;
 
 @Getter
-@RequiredArgsConstructor
 public class FileDownloadDto {
 
-	private final byte[] bytes;
+	private final Supplier<InputStream> content;
 
 	private final String name;
 
+	private final long length;
+
 	private final String type;
+
+	/**
+	 * deprecated. use {@link #FileDownloadDto(Supplier, long, String, String)}
+	 *
+	 * @param bytes file content
+	 * @param name file name
+	 * @param type file type
+	 */
+	@Deprecated(since = "4.0.0-M12", forRemoval = true)
+	public FileDownloadDto(byte[] bytes, String name, String type) {
+		this.content = bytes.length == 0 ? null : () -> new ByteArrayInputStream(bytes);
+		this.length = bytes.length;
+		this.name = name;
+		this.type = type;
+	}
+
+	/**
+	 * @param content file content
+	 * @param name file name
+	 * @param type`file type
+	 */
+	public FileDownloadDto(@NonNull Supplier<InputStream> content, long length, String name, String type) {
+		this.content = content;
+		this.length = length;
+		this.name = name;
+		this.type = type;
+	}
+
+	/**
+	 * deprecated. use {@link #getContent()}
+	 *
+	 * @return file content
+	 */
+	@Deprecated(since = "4.0.0-M12", forRemoval = true)
+	@SneakyThrows
+	public byte[] getBytes() {
+		return content == null ? new byte[0] : content.get().readAllBytes();
+	}
 
 }

--- a/cxbox-core/src/main/java/org/cxbox/core/file/service/CxboxFileService.java
+++ b/cxbox-core/src/main/java/org/cxbox/core/file/service/CxboxFileService.java
@@ -16,6 +16,7 @@
 
 package org.cxbox.core.file.service;
 
+import java.io.IOException;
 import org.cxbox.core.file.dto.FileDownloadDto;
 import jakarta.annotation.Nullable;
 import lombok.NonNull;
@@ -25,7 +26,6 @@ import org.springframework.web.multipart.MultipartFile;
 public interface CxboxFileService {
 
 	/**
-	 *
 	 * @param file entity to be saved
 	 * @param source (deprecated)
 	 * @return unique file id
@@ -33,14 +33,19 @@ public interface CxboxFileService {
 	<D extends FileDownloadDto> String upload(@NonNull D file, @Nullable String source);
 
 	/**
-	 *
 	 * @param file entity to be saved
 	 * @param source (deprecated)
 	 * @return unique file id
 	 */
 	@SneakyThrows
 	default String upload(@NonNull MultipartFile file, @Nullable String source) {
-		return upload(new FileDownloadDto(file.getBytes(), file.getOriginalFilename(), file.getContentType()), source);
+		return upload(new FileDownloadDto(() -> {
+			try {
+				return file.getInputStream();
+			} catch (IOException e) {
+				throw new IllegalStateException(e);
+			}
+		}, file.getSize(), file.getOriginalFilename(), file.getContentType()), source);
 	}
 
 	/**
@@ -55,6 +60,6 @@ public interface CxboxFileService {
 	 * @param id unique file id, that was returned by upload(...) method
 	 * @param source (deprecated)
 	 */
-	void remove(@NonNull  String id, @Nullable  String source);
+	void remove(@NonNull String id, @Nullable String source);
 
 }

--- a/cxbox-core/src/main/java/org/cxbox/core/file/service/CxboxFileServiceSimple.java
+++ b/cxbox-core/src/main/java/org/cxbox/core/file/service/CxboxFileServiceSimple.java
@@ -16,6 +16,7 @@
 
 package org.cxbox.core.file.service;
 
+import java.io.IOException;
 import org.cxbox.core.file.dto.FileDownloadDto;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -54,7 +55,7 @@ public class CxboxFileServiceSimple implements CxboxFileService {
 		String id = UUID.randomUUID().toString().replaceAll("-", "")
 				+ UNIQUE_PREFIX_SEPARATOR
 				+ file.getName();
-		FileCopyUtils.copy(file.getBytes(), Files.newOutputStream(getPathFromId(id)));
+		FileCopyUtils.copy(file.getContent().get(), Files.newOutputStream(getPathFromId(id)));
 		return id;
 	}
 
@@ -63,7 +64,14 @@ public class CxboxFileServiceSimple implements CxboxFileService {
 	public FileDownloadDto download(@NonNull String id, @Nullable String source) {
 		Path path = getPathFromId(id);
 		return new FileDownloadDto(
-				Files.readAllBytes(path),
+				() -> {
+					try {
+						return Files.newInputStream(path);
+					} catch (IOException e) {
+						throw new IllegalStateException(e);
+					}
+				},
+				Files.size(path),
 				path.getFileName().toString().substring(0, path.getFileName().toString().indexOf(UNIQUE_PREFIX_SEPARATOR)),
 				Files.probeContentType(path)
 		);

--- a/cxbox-core/src/main/java/org/cxbox/core/service/ResponsibilitiesService.java
+++ b/cxbox-core/src/main/java/org/cxbox/core/service/ResponsibilitiesService.java
@@ -28,7 +28,7 @@ public interface ResponsibilitiesService {
 
 	Map<String, Boolean> getAvailableViews(IUser<Long> user, String userRole);
 
-	List<ScreenResponsibility> getAvailableScreensResponsibilities(IUser<Long> user, String userRole);
+	List<ScreenResponsibility> getOverrideScreensResponsibilities(IUser<Long> user, String userRole);
 
 	List<String> getAvailableScreenViews(String screenName, IUser<Long> user, String userRole);
 

--- a/cxbox-starters/cxbox-meta-api/src/main/java/org/cxbox/dto/ScreenResponsibility.java
+++ b/cxbox-starters/cxbox-meta-api/src/main/java/org/cxbox/dto/ScreenResponsibility.java
@@ -16,6 +16,8 @@
 
 package org.cxbox.dto;
 
+import java.io.Serializable;
+import lombok.experimental.Accessors;
 import org.cxbox.api.data.dto.LocaleAware;
 import com.fasterxml.jackson.core.type.TypeReference;
 import java.util.List;
@@ -25,13 +27,17 @@ import lombok.Setter;
 
 @Getter
 @Setter
-public class ScreenResponsibility {
+@Accessors(chain = true)
+public class ScreenResponsibility implements Serializable {
 
 	public static final TypeReference<List<ScreenResponsibility>> LIST_TYPE_REFERENCE = new ListTypeReference();
 
 	private String id;
 
 	private String name;
+
+	//not used directly - used only for sorting on backend side
+	private Integer order;
 
 	@LocaleAware
 	private String text;
@@ -40,7 +46,8 @@ public class ScreenResponsibility {
 
 	private String icon;
 
-	private boolean defaultScreen;
+	@Deprecated(since = "4.0.0-M12")
+	private Boolean defaultScreen;
 
 	//ScreenDTO.class
 	private Object meta;

--- a/cxbox-starters/cxbox-starter-meta/src/main/java/org/cxbox/meta/entity/Responsibilities.java
+++ b/cxbox-starters/cxbox-starter-meta/src/main/java/org/cxbox/meta/entity/Responsibilities.java
@@ -61,7 +61,7 @@ public class Responsibilities extends BaseEntity {
 
 	@JdbcTypeCode(SqlTypes.NUMERIC)
 	@Column(name = "DEPT_ID")
-	private Long departmentId;
+	private Long departmentId = 0L;
 
 	@Column(name = "RESPONSIBILITIES")
 	private String view;
@@ -74,7 +74,7 @@ public class Responsibilities extends BaseEntity {
 	private boolean readOnly;
 
 	@Lob
-	@JdbcTypeCode(Types.CLOB)
+	@JdbcTypeCode(Types.VARCHAR)
 	private String screens;
 
 	public enum ResponsibilityType {

--- a/cxbox-starters/cxbox-starter-meta/src/main/java/org/cxbox/meta/metafieldsecurity/BcUtils.java
+++ b/cxbox-starters/cxbox-starter-meta/src/main/java/org/cxbox/meta/metafieldsecurity/BcUtils.java
@@ -42,6 +42,7 @@ import org.cxbox.core.crudma.bc.impl.InnerBcDescription;
 import org.cxbox.core.service.DTOSecurityUtils;
 import org.cxbox.core.service.ResponsibilitiesService;
 import org.cxbox.core.util.session.SessionService;
+import org.cxbox.meta.data.ScreenDTO;
 import org.cxbox.meta.metahotreload.repository.MetaRepository;
 import org.cxbox.meta.ui.field.IRequiredFieldsSupplier;
 import org.cxbox.meta.ui.model.BcField;
@@ -147,7 +148,7 @@ public class BcUtils implements ExtendedDtoFieldLevelSecurityService {
 		)
 		public Map<String, Set<BcField>> getDtoFieldsAvailableOnCurrentView(final String viewName) {
 			final Set<BcField> fields = new HashSet<>();
-			metaRepository.getAllScreens().forEach((name, screen) -> screen.getViews().forEach(view -> {
+			metaRepository.getAllScreens().forEach((name, screen) -> ((ScreenDTO) screen.getMeta()).getViews().forEach(view -> {
 				if (Objects.equals(view.getName(), viewName)) {
 					view.getWidgets().forEach(widget -> {
 						var widgetFields = new HashSet<>(widgetUtils.extractAllFields(widget));

--- a/cxbox-starters/cxbox-starter-meta/src/main/java/org/cxbox/meta/metahotreload/mapper/ScreenMapper.java
+++ b/cxbox-starters/cxbox-starter-meta/src/main/java/org/cxbox/meta/metahotreload/mapper/ScreenMapper.java
@@ -37,6 +37,7 @@ import lombok.SneakyThrows;
 import org.cxbox.api.config.CxboxBeanProperties;
 import org.cxbox.core.crudma.bc.BcRegistry;
 import org.cxbox.core.crudma.bc.impl.BcDescription;
+import org.cxbox.dto.ScreenResponsibility;
 import org.cxbox.meta.data.BcSourceBaseDTO;
 import org.cxbox.meta.data.BusinessComponentDTO;
 import org.cxbox.meta.data.BusinessObjectDTO;
@@ -73,7 +74,7 @@ public class ScreenMapper {
 
 	private final MetaConfigurationProperties metaConfigurationProperties;
 
-	public ScreenDTO map(ScreenSourceDto dto, Map<String, ViewDTO> viewNameToView, Map<String, BcProperties> bcProps, Map<String, List<FilterGroup>> filterGroupsAll) {
+	public ScreenResponsibility map(ScreenSourceDto dto, Map<String, ViewDTO> viewNameToView, Map<String, BcProperties> bcProps, Map<String, List<FilterGroup>> filterGroupsAll) {
 		List<String> currentScreenViewNames = new ArrayList<>();
 		ScreenDTO screenDTO = new ScreenDTO()
 				.setName(dto.getName())
@@ -88,7 +89,14 @@ public class ScreenMapper {
 				.setBo(getBusinessObject(intersection(viewNameToView, currentScreenViewNames).collect(Collectors.toMap(ViewDTO::getName, e -> e)), bcProps, filterGroupsAll))
 				.setPrimaries(JsonUtils.serializeOrElseNull(objectMapper, dto.getPrimaryViews()));
 		screenDTO.setId(String.valueOf(screenSeq.getAndIncrement()));
-		return screenDTO;
+		return new ScreenResponsibility()
+				.setMeta(screenDTO)
+				.setName(dto.getName())
+				.setOrder(dto.getOrder())
+				.setIcon(dto.getIcon())
+				.setText(dto.getTitle())
+				.setUrl("/screen/" + dto.getName())
+				.setId(screenDTO.getId());
 	}
 
 	private static Stream<ViewDTO> intersection(Map<String, ViewDTO> viewNameToView, List<String> screenViewsNames) {

--- a/cxbox-starters/cxbox-starter-meta/src/main/java/org/cxbox/meta/metahotreload/repository/MetaRepository.java
+++ b/cxbox-starters/cxbox-starter-meta/src/main/java/org/cxbox/meta/metahotreload/repository/MetaRepository.java
@@ -23,8 +23,8 @@ import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.cxbox.api.service.session.IUser;
 import org.cxbox.core.config.cache.CacheConfig;
+import org.cxbox.dto.ScreenResponsibility;
 import org.cxbox.meta.data.FilterGroupDTO;
-import org.cxbox.meta.data.ScreenDTO;
 import org.cxbox.meta.data.ViewDTO;
 import org.cxbox.meta.entity.BcProperties;
 import org.cxbox.meta.entity.BcProperties_;
@@ -109,6 +109,7 @@ public class MetaRepository {
 	public List<Responsibilities> getResponsibilityByUserAndRole(IUser<Long> user, String userRole,
 			ResponsibilityType responsibilityType) {
 		// В листе может быть не более одной записи
+
 		return jpaDao.getList(
 				Responsibilities.class,
 				(root, cq, cb) -> cb.and(
@@ -124,7 +125,7 @@ public class MetaRepository {
 			cacheNames = CacheConfig.UI_CACHE,
 			key = "{#root.methodName}"
 	)
-	public Map<String, ScreenDTO> getAllScreens() {
+	public Map<String, ScreenResponsibility> getAllScreens() {
 		//load data
 		var screens = metaResourceReaderService.getScreens();
 		var widgets = metaResourceReaderService.getWidgets();
@@ -141,7 +142,7 @@ public class MetaRepository {
 				.collect(Collectors.toMap(ViewDTO::getName, e -> e));
 		return screens.stream()
 				.map(screenSourceDto -> screenMapper.map(screenSourceDto, viewNameToView, bcProps, filterGroups))
-				.collect(Collectors.toMap(ScreenDTO::getName, e -> e));
+				.collect(Collectors.toMap(ScreenResponsibility::getName, e -> e));
 	}
 
 }


### PR DESCRIPTION
CXBOX-643 | Responsibilities table now do not require SCREEN records. Available screens now calculated at runtime. Screen records in Responsibilities table now used ONLY to override screen text, icon, order for CONCRETE ROLE.

Also, file controller now works with Steam IO instead of byte[]