### PR TITLE
fix release pom

### DIFF
--- a/cxbox-bom/pom.xml
+++ b/cxbox-bom/pom.xml
@@ -107,7 +107,7 @@
       <dependency>
         <groupId>org.cxbox</groupId>
         <artifactId>cxbox-dictionary-crudma</artifactId>
-        <version>4.0.0-M12-SNAPSHOT</version>
+        <version>4.0.0-M11</version>
       </dependency>
       <dependency>
         <groupId>org.cxbox</groupId>


### PR DESCRIPTION
pkg:maven/org.cxbox/cxbox-bom@4.0.0-M19
Dependency management dependencies to SNAPSHOT versions not allowed for dependency: org.cxbox:cxbox-dictionary-crudma